### PR TITLE
Add Datadog integration

### DIFF
--- a/Datadog/README.md
+++ b/Datadog/README.md
@@ -8,52 +8,66 @@ machine learning models. Use cases for monitoring inference-related metrics from
 machine learning models include detecting model drift, data drift, model bias,
 etc.
 
+Datadog is a cloud-based monitoring service that aggregates metrics and logs
+across different services. You can send Insights from Algorithmia to Datadog as
+time-series data that can then be analyzed in dashboards, monitors, and alerts.
+
 This integration allows you to stream operational metrics as well as
 user-defined, inference-related metrics from Algorithmia to Kafka to the metrics
 API in Datadog.
 
 ## Using this Algorithmia + Datadog integration
 
-1. Install Python if it's not already present on your system.
+1. Install Python.
 
 2. Clone this repository:
+
    ```
    git clone https://github.com/algorithmiaio/integrations.git
    ```
 
 3. Navigate to the directory with the Datadog integration:
+
    ```
    cd integrations/Datadog
    ```
 
 4. Install the required Python dependencies by running the following command:
+
    ```
    pip install -r requirements.txt
    ```
 
 5. Define the following environment variables (required):
+
    ```
    export DATADOG_API_KEY=<DATADOG-API-KEY>
    export KAFKA_BROKER=1.2.3.4:9092
    export KAFKA_TOPIC=insights
    ```
+
    and replace the values with your Datadog API key, Kafka broker URL and port,
    and Kafka topic that you want to consume Insights from.
 
 6. Run the Python script provided in this repository, which will continuously
    forward messages from Kafka to the Datadog metrics API:
+
    ```
    python kafka-datadog.py
    ```
+
    you can also run the Python script in the background using:
+
    ```
    python kafka-datadog.py &
    ```
-   or use a process supervision tool such as [supervisord][3] to manage the log
-   forwarding service and handle starting, stopping, and restarting the service.
+
+   or use a process supervision tool such as
+   [supervisord](http://supervisord.org/) to manage the log forwarding service
+   and handle starting, stopping, and restarting the service.
 
 ## Additional resources
 
 Refer to the documentation at
 https://github.com/DataDog/integrations-extras/algorithmia for more information
-about this integration.
+about this integration, including sample dashboards and monitors.

--- a/Datadog/README.md
+++ b/Datadog/README.md
@@ -1,0 +1,59 @@
+# Algorithmia + Datadog
+
+## Overview
+
+Algorithmia Insights is a feature of Algorithmia Enterprise and provides a
+metrics pipeline that can be used to instrument, measure, and monitor your
+machine learning models. Use cases for monitoring inference-related metrics from
+machine learning models include detecting model drift, data drift, model bias,
+etc.
+
+This integration allows you to stream operational metrics as well as
+user-defined, inference-related metrics from Algorithmia to Kafka to the metrics
+API in Datadog.
+
+## Using this Algorithmia + Datadog integration
+
+1. Install Python if it's not already present on your system.
+
+2. Clone this repository:
+   ```
+   git clone https://github.com/algorithmiaio/integrations.git
+   ```
+
+3. Navigate to the directory with the Datadog integration:
+   ```
+   cd integrations/Datadog
+   ```
+
+4. Install the required Python dependencies by running the following command:
+   ```
+   pip install -r requirements.txt
+   ```
+
+5. Define the following environment variables (required):
+   ```
+   export DATADOG_API_KEY=<DATADOG-API-KEY>
+   export KAFKA_BROKER=1.2.3.4:9092
+   export KAFKA_TOPIC=insights
+   ```
+   and replace the values with your Datadog API key, Kafka broker URL and port,
+   and Kafka topic that you want to consume Insights from.
+
+6. Run the Python script provided in this repository, which will continuously
+   forward messages from Kafka to the Datadog metrics API:
+   ```
+   python kafka-datadog.py
+   ```
+   you can also run the Python script in the background using:
+   ```
+   python kafka-datadog.py &
+   ```
+   or use a process supervision tool such as [supervisord][3] to manage the log
+   forwarding service and handle starting, stopping, and restarting the service.
+
+## Additional resources
+
+Refer to the documentation at
+https://github.com/DataDog/integrations-extras/algorithmia for more information
+about this integration.

--- a/Datadog/kafka-datadog.py
+++ b/Datadog/kafka-datadog.py
@@ -1,0 +1,61 @@
+import os
+import json
+import sys
+from datadog import initialize, api
+from kafka import KafkaConsumer
+
+try:
+    DATADOG_API_KEY = os.environ["DATADOG_API_KEY"]
+except KeyError:
+    sys.exit("Please define the DATADOG_API_KEY environment variable")
+
+try:
+    KAFKA_BROKER = os.environ["KAFKA_BROKER"]
+except KeyError:
+    sys.exit("Please define the KAFKA_BROKER environment variable")
+
+try:
+    KAFKA_TOPIC = os.environ["KAFKA_TOPIC"]
+except KeyError:
+    sys.exit("Please define the KAFKA_TOPIC environment variable")
+
+OPERATIONAL_METRICS = {"algorithm_version", "request_id", "time", "algorithm_name", "session_id", "algorithm_owner"}
+
+options = {"api_key": DATADOG_API_KEY}
+initialize(**options)
+
+# Set up Kafka consumer
+consumer = KafkaConsumer(
+    KAFKA_TOPIC,
+    bootstrap_servers=[KAFKA_BROKER],
+    value_deserializer=lambda m: json.loads(m.decode("ascii")),
+)
+
+# Consume data from Kafka topic
+for msg in consumer:
+    # Get JSON data from Algorithmia Insights
+    insight = msg.value
+
+    # Filter for inference metrics by removing known operational metrics
+    inference_metrics = {key: insight[key] for key in insight.keys() ^ OPERATIONAL_METRICS}
+
+    # Construct metrics payload
+    metrics_payload = []
+    for key, value in inference_metrics.items():
+        metrics_payload.append(
+            {
+                "metric": "algorithmia." + key,
+                "points": [insight["time"], value],
+                "type": "gauge",
+                "tags": [
+                    "algorithm_name:" + insight["algorithm_name"],
+                    "algorithm_version:" + insight["algorithm_version"],
+                    "algorithm_owner:" + insight["algorithm_owner"],
+                    "request_id:" + insight["request_id"],
+                    "session_id:" + insight["session_id"],
+                ],
+            }
+        )
+
+    # Send metrics to Datadog
+    api.Metric.send(metrics_payload)

--- a/Datadog/requirements.txt
+++ b/Datadog/requirements.txt
@@ -1,0 +1,2 @@
+datadog==0.39.0
+kafka-python==1.4.7


### PR DESCRIPTION
This integration allows you to stream operational metrics as well as user-defined, inference-related metrics from Algorithmia Insights to Kafka to the metrics API in Datadog.